### PR TITLE
feat: header

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,5 +17,11 @@
 	},
 	"browserslist": [
 		"defaults"
-	]
+	],
+	"dependencies": {
+		"@fortawesome/free-solid-svg-icons": "^6.2.1",
+		"install": "^0.13.0",
+		"npm": "^9.1.2",
+		"svelte-fa": "^3.0.3"
+	}
 }

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,11 +1,20 @@
 <script lang="ts">
+	import Header from '@components/Header.svelte'
 	const title = 'Wedington Photography'
 </script>
 
 <main id="app-wrapper">
-	<h1>{title}</h1>
+	<Header {title} />
 </main>
 
 <style lang="scss">
-	
+	@import './styles/colors';
+	#app-wrapper {
+		background-image: linear-gradient(32.5deg, $color-extra-deep-purple, 50%, $color-extra-lilac);
+		width: 100vw;
+		height: 100vh;
+		display: flex;
+		justify-content: center;
+		align-items: flex-start;
+	}
 </style>

--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+  import Fa from 'svelte-fa/src/fa.svelte'
+  import { faBars } from '@fortawesome/free-solid-svg-icons'
+  export let title: string
+</script>
+
+<header id="app-header">
+  <h2>{title}</h2>
+  <nav>
+    <a href="/">
+      <span>Menu</span>
+      <Fa class="icon" icon={faBars} style="margin-right: 0.5rem" />
+    </a>
+  </nav>
+</header>
+
+<style lang="scss">
+  @import '../styles/colors';
+  @import '../styles/typography';
+  #app-header {
+    width: 100%;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    background: linear-gradient(0deg, $color-near-black, 50%, $color-dgray);
+		box-shadow: 0 1rem 1rem rgba(0,0,0,0.3);
+
+    h2 {
+      color: $color-near-white;
+      padding: 1rem;
+      margin: 0;
+    }
+
+    nav {
+
+      a {
+        text-decoration: none;
+        color: $color-white;
+        transition: all 1s ease-in-out;
+      }
+
+      span {
+        display: inline;
+        padding: 1rem;
+        padding-right: 0.5rem;
+        @include font-dm-sans;
+        color: $color-lgray;
+        text-decoration: none;
+        font-weight: bold;
+        text-transform: uppercase;
+        transition: all 0.5s ease-in-out;
+      }
+
+      &:hover, &:active, &.active {
+        a, span {
+          color: $color-extra-lilac;
+        }
+      }
+    }
+  }
+</style>

--- a/src/styles/_colors.scss
+++ b/src/styles/_colors.scss
@@ -1,0 +1,35 @@
+// GrayScale
+$color-white: #FEFEFE;
+$color-near-white: #EFEFEF;
+$color-lgray: #CCCCCC;
+$color-creme: #AAAAAA;
+$color-gray: #999999;
+$color-dgray: #666666;
+$color-dark: #333333;
+$color-near-black: #131313;
+$color-black: #030303;
+
+// Warm
+$color-warm-first: #EAE7DC;
+$color-warm-second: #D8C3A5;
+$color-warm-third: #8E8D8A;
+$color-warm-fourth: #E98974;
+$color-warm-fifth: #E85A4F;
+
+// Sharp
+$color-sharp-first: #d83f87;
+$color-sharp-second: #2A1B3D;
+$color-sharp-third: #44318D;
+$color-sharp-fourth: #E98074;
+$color-sharp-fifth: #A4B3B6;
+
+// Contrast
+$color-contrast-first: #61892F;
+$color-contrast-second: #86C232;
+$color-contrast-third: #222629;
+$color-contrast-fourth: #474B4F;
+$color-contrast-fifth: #6B6E70;
+
+// Used
+$color-extra-deep-purple: #20002c;
+$color-extra-lilac: #cbb4d4;

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -1,4 +1,5 @@
 @import '@styles/typography';
+@import '@styles/colors';
 html, body {
 	position: relative;
 	min-width: 100vw;
@@ -8,24 +9,14 @@ html, body {
 }
 
 body {
-	color: #333;
 	box-sizing: border-box;
 	@include font-feredo;
 	min-width: 100vw;
 	min-height: 100vh;
-
-	#app-wrapper {
-		background: #CCC;
-		width: 100vw;
-		height: 100vh;
-		display: flex;
-		justify-content: center;
-		align-items: flex-start;
-	}
 }
 
 a {
-	color: rgb(0,100,200);
+	color: $color-contrast-second;
 	text-decoration: none;
 
 	&:hover {
@@ -33,6 +24,6 @@ a {
 	}
 
 	&:visited {
-		color: rgb(0,80,160);
+		color: $color-contrast-first;
 	}
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
 		"baseUrl": ".",
 		"paths": {
 			"@src/*": ["src/*"],
-			"@styles": ["src/styles/*"]
+			"@components/*": ["src/components/*"],
+			"@styles/*": ["src/styles/*"]
 		},
 		"types": [
 			"svelte",


### PR DESCRIPTION
Added basic header.

Compartmentalized the menu and icon into a single, clickable anchor element.

Ready for other component creation.

<img width="308" alt="image" src="https://user-images.githubusercontent.com/7076829/204075362-44cdf242-d213-4578-9fa0-97065f152735.png">
